### PR TITLE
Fix issue where subfolders aren’t checked for existence before creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,7 +366,10 @@ function mkdir(dirname, options = {}) {
   const opts = Object.assign({ cwd: process.cwd(), fs }, options);
   const mode = opts.mode || 0o777 & ~process.umask();
   const segs = path.relative(opts.cwd, dirname).split(path.sep);
-  const make = dir => fs.mkdirSync(dir, mode);
+  const make = dir => {
+    if (fs.existsSync(dir)) return;
+    fs.mkdirSync(dir, mode);
+  };
   for (let i = 0; i <= segs.length; i++) {
     try {
       make((dirname = path.join(opts.cwd, ...segs.slice(0, i))));


### PR DESCRIPTION
Getting an error when trying to save the store to `/data/store`, if a subfolder already exists the mkdir method doesn't check for it and throw an error.

```
Error: EEXIST: file already exists, mkdir '/'
    at Object.fs.mkdirSync (fs.js:885:18)
    at make (/cilia/node_modules/data-store/index.js:369:26)
    at mkdir (/cilia/node_modules/data-store/index.js:372:7)
    at Store.writeFile (/cilia/node_modules/data-store/index.js:288:5)
    at ontimeout (timers.js:475:11)
    at tryOnTimeout (timers.js:310:5)
    at Timer.listOnTimeout (timers.js:270:5)
````