### PR TITLE
Fix readme table formatting

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -31,7 +31,7 @@ console.log(store.data);
 | **Option** | **Type** | **Default** | **Description** |
 | --- | --- | --- | --- |
 | `debounce` | `number` | `undefined` | Milliseconds to delay writing the JSON file to the file system. This can make the store more performant by preventing multiple subsequent writes after calling `.set` or setting/getting `store.data`, but comes with the potential side effect that the config file will be outdated during the timeout. To get around this, use data-store's API to [(re-)load](#load) the file instead of directly reading the file (using `fs.readFile` for example). |
-| `indent` | `number|null` | `2` | The indent value to pass to `JSON.stringify()` when writing the file to the fs, or when [.json()](#json) is called |
+| `indent` | `number∣null` | `2` | The indent value to pass to `JSON.stringify()` when writing the file to the fs, or when [.json()](#json) is called |
 | `name` | `string` | `undefined` | The name to use for the store file stem (`name + '.json'` is the store's file name) |
 | `home` | `string` | `process.env.XDG_CONFIG_HOME` or `path.join(os.homedir(), '.config')` | The root home directory to use |
 | `base` | `string` | `path.join(home, 'data-store')` | The directory to use for data-store config files. This value is joined to `home` |


### PR DESCRIPTION
Github, or the readme generator don't like the pipe (`|`) character denoting either a number or null for the `indent` property. I copied a different character (`∣`) which looks like the pipe character. (From [wikipedia](https://en.wikipedia.org/wiki/Vertical_bar) on the right side of the page, above the word "Divides").

Since I'm doing this on the github editor, I didn't re-generate the readme.