### PR TITLE
Allow append to existing object; allow user-provided read/write functions

### DIFF
--- a/examples/ini.js
+++ b/examples/ini.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+lconst fs = require('fs');
 const ini = require('ini');
 const utils = require('../utils');
 const path = require('path');
@@ -17,9 +17,9 @@ function readParseFile() {
   
   console.log('readParseFile');
   try {
-    data = fs.readFileSync(this.path, "utf-8");
+    data = fs.readFileSync(this.path, 'utf-8');
   } catch (e) {
-    console.log(`readParseFile error; starting with empty data`);
+    console.log('readParseFile error; starting with empty data');
     data = {};
   }
 
@@ -27,14 +27,12 @@ function readParseFile() {
   return ini.parse(data);
 }
 
-const store = new Store(
-  'app',
-  {
-    path: __dirname + '/data.ini',
-    debounce: 10,
-    writeFile: writeFile,
-    readParseFile: readParseFile
-  });
+const store = new Store('app', {
+  path: __dirname + '/data.ini',
+  debounce: 10,
+  writeFile: writeFile,
+  readParseFile: readParseFile
+});
 
 store.merge('section 1', { a : 'b' });
 store.merge('section 1', { c : 'd' });

--- a/examples/ini.js
+++ b/examples/ini.js
@@ -1,0 +1,47 @@
+const fs = require("fs");
+const ini = require("ini");
+const utils = require('../utils');
+const path = require('path');
+const Store = require('../');
+
+// Will be called in context of store
+function writeFile() {
+  console.log("writeFile");
+  utils.mkdir(path.dirname(this.path));
+  fs.writeFileSync(this.path, ini.stringify(this.data), { mode: 0o0600 });
+}
+
+// Will be called in context of store
+function readParseFile() {
+  let data;
+  
+  console.log("readParseFile");
+  try
+  {
+    data = fs.readFileSync(this.path, "utf-8");
+  }
+  catch (e)
+  {
+    console.log(`readParseFile error; starting with empty data`);
+    data = {};
+  }
+
+  // Parse the INI-format configuration file
+  return ini.parse(data);
+}
+
+const store = new Store(
+  'app',
+  {
+    path: __dirname + '/data.ini',
+    debounce: 10,
+    writeFile: writeFile,
+    readParseFile: readParseFile
+  });
+
+store.append("section 1", { a : 'b' });
+store.append("section 1", { c : 'd' });
+store.set("section 2", { e : 'f' });
+console.log(store.data);
+
+//store.unlink();

--- a/examples/ini.js
+++ b/examples/ini.js
@@ -1,4 +1,4 @@
-lconst fs = require('fs');
+const fs = require('fs');
 const ini = require('ini');
 const utils = require('../utils');
 const path = require('path');

--- a/examples/ini.js
+++ b/examples/ini.js
@@ -1,12 +1,12 @@
-const fs = require("fs");
-const ini = require("ini");
+const fs = require('fs');
+const ini = require('ini');
 const utils = require('../utils');
 const path = require('path');
 const Store = require('../');
 
 // Will be called in context of store
 function writeFile() {
-  console.log("writeFile");
+  console.log('writeFile');
   utils.mkdir(path.dirname(this.path));
   fs.writeFileSync(this.path, ini.stringify(this.data), { mode: 0o0600 });
 }
@@ -15,13 +15,10 @@ function writeFile() {
 function readParseFile() {
   let data;
   
-  console.log("readParseFile");
-  try
-  {
+  console.log('readParseFile');
+  try {
     data = fs.readFileSync(this.path, "utf-8");
-  }
-  catch (e)
-  {
+  } catch (e) {
     console.log(`readParseFile error; starting with empty data`);
     data = {};
   }
@@ -39,9 +36,9 @@ const store = new Store(
     readParseFile: readParseFile
   });
 
-store.merge("section 1", { a : 'b' });
-store.merge("section 1", { c : 'd' });
-store.set("section 2", { e : 'f' });
+store.merge('section 1', { a : 'b' });
+store.merge('section 1', { c : 'd' });
+store.set('section 2', { e : 'f' });
 console.log(store.data);
 
 //store.unlink();

--- a/examples/ini.js
+++ b/examples/ini.js
@@ -39,8 +39,8 @@ const store = new Store(
     readParseFile: readParseFile
   });
 
-store.append("section 1", { a : 'b' });
-store.append("section 1", { c : 'd' });
+store.merge("section 1", { a : 'b' });
+store.merge("section 1", { c : 'd' });
 store.set("section 2", { e : 'f' });
 console.log(store.data);
 

--- a/index.js
+++ b/index.js
@@ -101,25 +101,35 @@ class Store {
 
   /**
    * Assign `value` to `key` while retaining prior members of `value` if
-   * `value` is a map.
+   * `value` is a map. If `value` is not a map, overwrites like `.set`.
    *
    * ```js
    * store.set('a', { b: c });
    * //=> {a: { b: c }}
    *
-   * store.append('a', { d: e });
+   * store.merge('a', { d: e });
    * //=> {a: { b: c, d: e }}
+   *
+   * store.set('a', 'b');
+   * //=> {a: 'b'}
+   *
+   * store.merge('a', { c : 'd' });
+   * //=> {a: { c : 'd' }}
    * ```
    *
-   * @name .append
+   * @name .merge
    * @param {String} `key`
-   * @param {any} `val` The value to append to `key`. Must be a valid JSON type: String, Number, Array or Object.
+   * @param {any} `val` The value to merge to `key`. Must be a valid JSON type: String, Number, Array or Object.
    * @return {Object} `Store` for chaining
    * @api public
    */
 
-  append(key, val) {
-    return this.set(key, Object.assign(this.get(key) || {}, val));
+  merge(key, val) {
+    let oldVal = this.get(key);
+    if (oldVal && typeof oldVal == "object" && ! Array.isArray(oldVal)) {
+      val = Object.assign(this.get(key), val);
+    }
+    return this.set(key, val);
   }
 
   /**
@@ -367,7 +377,7 @@ class Store {
    */
 
   readParseFile() {
-    return JSON.parsefs.readFileSync(this.path);
+    return JSON.parse(fs.readFileSync(this.path));
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -53,10 +53,10 @@ class Store {
     this.timeouts = {};
 
     // Allow override of read and write methods
-    if (typeof options.readParseFile == "function") {
+    if (typeof options.readParseFile === 'function') {
       this.readParseFile = options.readParseFile;
     }
-    if (typeof options.writeFile == "function") {
+    if (typeof options.writeFile === 'function') {
       this.writeFile = options.writeFile;
     }
   }
@@ -126,7 +126,7 @@ class Store {
 
   merge(key, val) {
     let oldVal = this.get(key);
-    if (oldVal && typeof oldVal == "object" && ! Array.isArray(oldVal)) {
+    if (oldVal && typeof oldVal === 'object' && !Array.isArray(oldVal)) {
       val = Object.assign(this.get(key), val);
     }
     return this.set(key, val);
@@ -373,7 +373,7 @@ class Store {
    * data = store.readPraseFile();
    * ```
    * @name .readParseFile
-   * @return {undefined}
+   * @return {Object}
    */
 
   readParseFile() {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "delete": "^1.1.0",
     "gulp-format-md": "^2.0.0",
-    "mocha": "^6.2.0"
+    "mocha": "^6.2.1"
   },
   "keywords": [
     "app",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "devDependencies": {
     "delete": "^1.1.0",
     "gulp-format-md": "^2.0.0",
-    "mocha": "^6.2.1"
+    "ini": "^1.3.5",
+    "mocha": "^6.2.0"
   },
   "keywords": [
     "app",

--- a/test/test.js
+++ b/test/test.js
@@ -101,23 +101,30 @@ describe('store', () => {
     });
   });
 
-  describe('append', () => {
+  describe('merge', () => {
     it('should allow adding to an existing map', () => {
-      store.append('a', { b : 'c' });
-      store.append('d', { e : 'f' });
+      store.merge('a', { b : 'c' });
+      store.merge('d', { e : 'f' });
       store.set('g', { h : 'i' });
       assert.equal(store.data.a.b, 'c');
       assert.equal(store.data.d.e, 'f');
       assert.equal(store.data.g.h, 'i');
     });
+
     it('should allow overriding an existing key in an existing map', () => {
-      store.append('a', { b : 'c' });
-      store.append('d', { e : 'f' });
+      store.merge('a', { b : 'c' });
+      store.merge('d', { e : 'f' });
       store.set('g', { h : 'i' });
-      store.append('d', { e : 'j' });
+      store.merge('d', { e : 'j' });
       assert.equal(store.data.a.b, 'c');
       assert.equal(store.data.d.e, 'j');
       assert.equal(store.data.g.h, 'i');
+    });
+
+    it('should just overwrite if merge to non-object', () => {
+      store.set('a', 'b');
+      store.merge('a', { c : 'd' });
+      assert.equal(store.data.a.c, 'd');
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,26 @@ describe('store', () => {
     });
   });
 
+  describe('append', () => {
+    it('should allow adding to an existing map', () => {
+      store.append('a', { b : 'c' });
+      store.append('d', { e : 'f' });
+      store.set('g', { h : 'i' });
+      assert.equal(store.data.a.b, 'c');
+      assert.equal(store.data.d.e, 'f');
+      assert.equal(store.data.g.h, 'i');
+    });
+    it('should allow overriding an existing key in an existing map', () => {
+      store.append('a', { b : 'c' });
+      store.append('d', { e : 'f' });
+      store.set('g', { h : 'i' });
+      store.append('d', { e : 'j' });
+      assert.equal(store.data.a.b, 'c');
+      assert.equal(store.data.d.e, 'j');
+      assert.equal(store.data.g.h, 'i');
+    });
+  });
+
   describe('union', () => {
     it('should add and arrayify a new value', () => {
       store.union('one', 'two');


### PR DESCRIPTION
The following changes are included here:

1. New Method: append

A new `append` method has been added. Whereas the traditional calls such as
```
store.set('a', { b : c });
store.set('a', { d : e });
```
allows the second call to overwrite the entire value of 'a', yielding
```
{
  d : e
}
```

this sequence:
```
store.append('a', { b : c });
store.append('a', { d : e });
```
ratains prior values, and thus yields:
```
{
  b : c,
  d : e
}
```

2. The means of reading (and parsing), and writing to files can now be
overridden by the caller, in the `options` argument. This allows adding
additional error handling, in the simple case, or reading and writing entirely
different types of files in the more sophisticated case. An example is
provided in `examples/ini.js` that shows the store reading and writing an INI
file, while allowing it to be manipulated programmatically in the standard
data-store fashion.
