### PR TITLE
Fix TS parameter type to delete multiple keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare module 'data-store' {
      * Delete one or more properties from the store.
      */
 
-    del: (...keys: string[]) => void
+    del: (keys: string | string[]) => void
 
     /**
      * Return a clone of the store.data object.


### PR DESCRIPTION
Allow deletion of multiple keys at the same time using TypeScript.

We can also modify the method in index.js to allow the ...keys approach which would be nicer. However, this was the least invasive fix