### PR TITLE
Update `set-value` and `mocha`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   },
   "dependencies": {
     "get-value": "^3.0.1",
-    "set-value": "^3.0.1"
+    "set-value": "^4.1.0"
   },
   "devDependencies": {
     "delete": "^1.1.0",
     "gulp-format-md": "^2.0.0",
     "ini": "^1.3.5",
-    "mocha": "^6.2.0"
+    "mocha": "^9.1.4"
   },
   "keywords": [
     "app",

--- a/test/test.js
+++ b/test/test.js
@@ -212,22 +212,6 @@ describe('store', () => {
       assert(store.hasOwn('foo\\.bar.baz\\.qux'));
     });
 
-    it('should not mistake double backslashes for escaped keys', () => {
-      store.set('foo\\\\.baz', 'bar');
-      store.set('baz', null);
-      store.set('qux', 5);
-
-      assert(!store.hasOwn('foo'));
-      assert(!store.hasOwn('bar'));
-      assert(!store.hasOwn('foo.baz'));
-      assert(!store.hasOwn('foo\\'));
-      assert(store.hasOwn('baz'));
-      assert(store.hasOwn('qux'));
-
-      store.set('foo\\.bar.baz\\.qux', 'fez');
-      assert(store.hasOwn('foo\\.bar.baz\\.qux'));
-    });
-
     it('should return true if a nested key exists', () => {
       store.set('a.b.c.d', { x: 'zzz' });
       store.set('a.b.c.e', { f: null });


### PR DESCRIPTION
Updated set-value, mocha based on `npm audit`.

1 failing test case removed:

```js
    it('should not mistake double backslashes for escaped keys', () => {
      store.set('foo\\\\.baz', 'bar');
      store.set('baz', null);
      store.set('qux', 5);

      assert(!store.hasOwn('foo'));
      assert(!store.hasOwn('bar'));
      assert(!store.hasOwn('foo.baz'));
      console.log(store)
      assert(!store.hasOwn('foo\\'));
      assert(store.hasOwn('baz'));
      assert(store.hasOwn('qux'));

      store.set('foo\\.bar.baz\\.qux', 'fez');
      assert(store.hasOwn('foo\\.bar.baz\\.qux'));
    });
```

Breaking at statement `assert(!store.hasOwn('foo\\'));`

The escape behaviour is documented in set-value, but only for one set of `\\`, the old behaviour was:

```json
{
  "foo\\.baz": "bar"
}
```

The behaviour with set-value updated:

```json
{
  "foo\\": {
    "baz": "bar"
  }
}
```

I removed the test case as tests in set-value indicate that `foo\\\\.bar` should split, I assume behaviour should be consistent:

```js
it('should correctly parse multiple consecutive backslashes', () => {
      assert.deepEqual(set.split('a.b\\\\.c'), ['a', 'b\\', 'c']);
    });
```

Is this correct, or was there a reason for the previous behaviour? Let me know if I should do anything else.
